### PR TITLE
Add authentication middleware

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,21 @@
+import { middleware } from './middleware'
+import { NextRequest } from 'next/server'
+
+// Helper to create NextRequest with optional cookies
+function createRequest(url: string, cookie?: string) {
+  return new NextRequest(new Request(url, cookie ? { headers: { cookie } } : {}));
+}
+
+describe('middleware', () => {
+  it('redirects unauthenticated users', () => {
+    const req = createRequest('https://example.com/protected');
+    const res = middleware(req)!
+    expect(res.headers.get('location')).toContain('/login');
+  });
+
+  it('allows authenticated users', () => {
+    const req = createRequest('https://example.com/protected', 'authToken=abc');
+    const res = middleware(req);
+    expect(res.headers.get('location')).toBeNull();
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,17 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get("authToken")?.value;
+
+  if (!token && !request.nextUrl.pathname.startsWith("/login")) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("returnUrl", request.nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
## Summary
- add middleware to enforce auth cookie and redirect to login
- add tests for middleware

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868bc04ef1c832c90411aacdb6739f7